### PR TITLE
Old? NMS function import error

### DIFF
--- a/src/juxtapose/utils/core.py
+++ b/src/juxtapose/utils/core.py
@@ -6,7 +6,7 @@ from typing import Any, Iterator, List, Optional, Tuple
 
 import numpy as np
 
-from supervision.detection.utils import non_max_suppression, xywh_to_xyxy
+from supervision.detection.utils import box_non_max_suppression, xywh_to_xyxy
 from supervision.geometry.core import Position
 
 
@@ -450,7 +450,7 @@ class Detections:
 
         if class_agnostic:
             predictions = np.hstack((self.xyxy, self.confidence.reshape(-1, 1)))
-            indices = non_max_suppression(
+            indices = box_non_max_suppression(
                 predictions=predictions, iou_threshold=threshold
             )
             return self[indices]
@@ -463,5 +463,5 @@ class Detections:
         predictions = np.hstack(
             (self.xyxy, self.confidence.reshape(-1, 1), self.class_id.reshape(-1, 1))
         )
-        indices = non_max_suppression(predictions=predictions, iou_threshold=threshold)
+        indices = box_non_max_suppression(predictions=predictions, iou_threshold=threshold)
         return self[indices]


### PR DESCRIPTION
### Env:
- Python 3.10.13
- fresh venv
git clone https://github.com/ziqinyeow/juxtapose
pip install .

### Script:
from juxtapose import RTM
import time

model = RTM(
    det="rtmdet-s", # see type hinting
    pose="rtmpose-s", # see type hinting
    tracker="bytetrack", # see type hinting
    device="cpu",  # see type hinting
)
start_time = time.time()
model("0data/lots_of_persons.mp4")

print(f"Time: {time.time() - start_time:.2f}s")

### Error:
Traceback (most recent call last):
  File "/Users/REDACT/Projects/0scratch/building_standalone_tracker/juxtapose_test.py", line 1, in <module>
    from juxtapose import RTM
  File "/Users/REDACT/.pyenv/versions/3.10.13/lib/python3.10/site-packages/juxtapose/__init__.py", line 3, in <module>
    from .rtm import RTM
  File "/Users/REDACT/.pyenv/versions/3.10.13/lib/python3.10/site-packages/juxtapose/rtm.py", line 14, in <module>
    from juxtapose.detectors import get_detector
  File "/Users/REDACT/.pyenv/versions/3.10.13/lib/python3.10/site-packages/juxtapose/detectors/__init__.py", line 2, in <module>
    from .rtmdet import RTMDet
  File "/Users/REDACT/.pyenv/versions/3.10.13/lib/python3.10/site-packages/juxtapose/detectors/rtmdet/__init__.py", line 7, in <module>
    from juxtapose.utils.core import Detections
  File "/Users/REDACT/.pyenv/versions/3.10.13/lib/python3.10/site-packages/juxtapose/utils/core.py", line 9, in <module>
    from supervision.detection.utils import non_max_suppression, xywh_to_xyxy
ImportError: cannot import name 'non_max_suppression' from 'supervision.detection.utils' (/Users/REDACT/.pyenv/versions/3.10.13/lib/python3.10/site-packages/supervision/detection/utils.py)


Fix